### PR TITLE
MOD: output tracing when switch is on

### DIFF
--- a/src/redis/fixed_cache_impl.go
+++ b/src/redis/fixed_cache_impl.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/envoyproxy/ratelimit/src/config"
 	"github.com/envoyproxy/ratelimit/src/limiter"
+	"github.com/envoyproxy/ratelimit/src/settings"
 	"github.com/envoyproxy/ratelimit/src/utils"
 )
 
@@ -93,14 +94,16 @@ func (this *fixedRateLimitCacheImpl) DoLimit(
 		}
 	}
 
-	// Generate trace
-	_, span := tracer.Start(ctx, "Redis Pipeline Execution",
-		trace.WithAttributes(
-			attribute.Int("pipeline length", len(pipeline)),
-			attribute.Int("perSecondPipeline length", len(perSecondPipeline)),
-		),
-	)
-	defer span.End()
+	if settings.TracingEnabled {
+		// Generate trace
+		_, span := tracer.Start(ctx, "Redis Pipeline Execution",
+			trace.WithAttributes(
+				attribute.Int("pipeline length", len(pipeline)),
+				attribute.Int("perSecondPipeline length", len(perSecondPipeline)),
+			),
+		)
+		defer span.End()
+	}
 
 	if pipeline != nil {
 		checkError(this.client.PipeDo(pipeline))

--- a/src/server/server_impl.go
+++ b/src/server/server_impl.go
@@ -99,13 +99,15 @@ func NewJsonHandler(svc pb.RateLimitServiceServer) func(http.ResponseWriter, *ht
 			return
 		}
 
-		// Generate trace
-		_, span := tracer.Start(ctx, "NewJsonHandler Remaining Execution",
-			trace.WithAttributes(
-				attribute.String("response", resp.String()),
-			),
-		)
-		defer span.End()
+		if settings.TracingEnabled {
+			// Generate trace
+			_, span := tracer.Start(ctx, "NewJsonHandler Remaining Execution",
+				trace.WithAttributes(
+					attribute.String("response", resp.String()),
+				),
+			)
+			defer span.End()
+		}
 
 		logger.Debugf("resp:%s", resp)
 

--- a/src/service/ratelimit.go
+++ b/src/service/ratelimit.go
@@ -267,14 +267,16 @@ func (this *service) ShouldRateLimit(
 	ctx context.Context,
 	request *pb.RateLimitRequest) (finalResponse *pb.RateLimitResponse, finalError error) {
 
-	// Generate trace
-	_, span := tracer.Start(ctx, "ShouldRateLimit Execution",
-		trace.WithAttributes(
-			attribute.String("domain", request.Domain),
-			attribute.String("request string", request.String()),
-		),
-	)
-	defer span.End()
+	if settings.TracingEnabled {
+		// Generate trace
+		_, span := tracer.Start(ctx, "ShouldRateLimit Execution",
+			trace.WithAttributes(
+				attribute.String("domain", request.Domain),
+				attribute.String("request string", request.String()),
+			),
+		)
+		defer span.End()
+	}
 
 	defer func() {
 		err := recover()

--- a/src/service_cmd/main.go
+++ b/src/service_cmd/main.go
@@ -6,6 +6,8 @@ import (
 )
 
 func main() {
-	runner := runner.NewRunner(settings.NewSettings())
+	s := settings.NewSettings()
+	settings.TracingEnabled = s.TracingEnabled
+	runner := runner.NewRunner(s)
 	runner.Run()
 }

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -10,6 +10,7 @@ import (
 	"github.com/envoyproxy/ratelimit/src/utils"
 )
 
+var TracingEnabled bool 
 type Settings struct {
 	// runtime options
 	// This value shall be imported into unary server interceptor in order to enable chaining


### PR DESCRIPTION
根据火焰图分析，
![image](https://user-images.githubusercontent.com/7498344/192969804-0ceda690-4daf-49b6-8bca-1312d5c80c32.png)

下面代码中的request.String() 消耗了大量cpu，而我们目前不需要tracing 信息，所以优化了一下，当开启tracing开关时才输出tracing信息。 
`
func (this *service) ShouldRateLimit(
	ctx context.Context,
	request *pb.RateLimitRequest) (finalResponse *pb.RateLimitResponse, finalError error) {

	if bootstrapSettings := settings.BootstrapSettings(); bootstrapSettings.TracingEnabled {
		// Generate trace
		_, span := tracer.Start(ctx, "ShouldRateLimit Execution",
			trace.WithAttributes(
				attribute.String("domain", request.Domain),
				attribute.String("request string", request.String()),
			),
		)
		defer span.End()
	}
`